### PR TITLE
fix(oui-table): remove spacing between cells when Bootstrap is not loaded

### DIFF
--- a/packages/oui-table/_mixins.less
+++ b/packages/oui-table/_mixins.less
@@ -11,6 +11,7 @@
     width: @width;
     border: 0;
     border-collapse: separate;
+    border-spacing: 0;
     margin: @margin;
     text-align: left;
   }


### PR DESCRIPTION
Signed-off-by: Kevin Manson kevin.manson@corp.ovh.com