### PR TITLE
fix(oui-modal): load the correct font

### DIFF
--- a/packages/oui-modal/_normalize.less
+++ b/packages/oui-modal/_normalize.less
@@ -1,0 +1,7 @@
+@import '../oui-typography/_mixins';
+
+#oui {
+  .modal-normalize() {
+    #oui > .base-font();
+  }
+}

--- a/packages/oui-modal/modal.less
+++ b/packages/oui-modal/modal.less
@@ -1,7 +1,10 @@
+@import './_normalize';
 @import './_mixins';
 
 .oui-modal {
   @oui-button-selector: oui-button;
+
+  #oui > .modal-normalize();
 
   #oui > .modal-base(@oui-button-selector);
   #oui > .modal-warning();


### PR DESCRIPTION
    default font => as defined by base-font mixin.

 Signed-off-by: Mathieu Boulianne <mathieu.boulianne@corp.ovh.com>