### PR TITLE
docs(integration): fix oui-formfield path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Those dependencies will be installed automatically by npm:
 
 @import "./node_modules/ovh-ui-kit/packages/oui-button/button";
 @import "./node_modules/ovh-ui-kit/packages/oui-radio/radio";
-@import "./node_modules/ovh-ui-kit/packages/oui-field/field";
+@import "./node_modules/ovh-ui-kit/packages/oui-formfield/formfield";
 
 [...]
 ```
@@ -46,7 +46,7 @@ Webpack provide the `~` prefix for package imports:
 
 @import "~ovh-ui-kit/packages/oui-button/button.less";
 @import "~ovh-ui-kit/packages/oui-radio/radio.less";
-@import "~ovh-ui-kit/packages/oui-field/field.less";
+@import "~ovh-ui-kit/packages/oui-formfield/formfield.less";
 
 [...]
 ```

--- a/packages/oui-formfield/README.md
+++ b/packages/oui-formfield/README.md
@@ -37,8 +37,8 @@ oui-formfield is a package which provides styles for the formfield component.
 
 <div class="oui-input-group">
   <div class="oui-input-formfield">
-    <input type="text" id="text" name="text" class="oui-input" value="Input text" />
-    <label for="text" class="oui-label">Label for Input group</label>
+    <input type="text" id="text-group" name="text-group" class="oui-input" value="Input text" />
+    <label for="text-group" class="oui-label">Label for Input group</label>
   </div>
   <button class="oui-button">Go</button>
 </div>


### PR DESCRIPTION
I noticed that the name of this component can still be changed at any moment but I'd like to keep the README.md file sync.