### PR TITLE
bugfix(oui-input-group): fix max-width on numeric input group on firefox

### DIFF
--- a/packages/oui-input-group/_mixins.less
+++ b/packages/oui-input-group/_mixins.less
@@ -157,6 +157,10 @@
 
     .@{input-selector} {
       text-align: center;
+      // Two lines bellow are required by firefox otherwise the max-width
+      // defined at root of the mixin isn't applied correctly
+      flex-shrink: 1;
+      min-width: 1px;
     }
   }
 }


### PR DESCRIPTION
max-width wasn't applied correctly only on firefox, so I fixed it.