### PR TITLE
fix(oui-loader): add centered alignment by default

### DIFF
--- a/packages/oui-loader/_mixins.less
+++ b/packages/oui-loader/_mixins.less
@@ -25,7 +25,6 @@
     }
 
     &__container {
-      margin: auto;
       display: block;
       position: relative;
       background: none;
@@ -110,5 +109,13 @@
   .loader-inline() {
     display: inline-block;
     vertical-align: text-top;
+  }
+
+  .loader-center() {
+    text-align: center;
+
+    &__container {
+      margin: auto;
+    }
   }
 }

--- a/packages/oui-loader/_mixins.less
+++ b/packages/oui-loader/_mixins.less
@@ -25,6 +25,7 @@
     }
 
     &__container {
+      margin: auto;
       display: block;
       position: relative;
       background: none;

--- a/packages/oui-loader/loader.less
+++ b/packages/oui-loader/loader.less
@@ -19,4 +19,8 @@
   &_inline {
     #oui > .loader-inline();
   }
+
+  &_center {
+    #oui > .loader-center();
+  }
 }


### PR DESCRIPTION
By default, the loader has no alignment and is `display: block`. 
90% of the use of `<oui-loader>` in managers are inline loaders in a text-centered container for a page/view loading:

```
<div class="text-center" data-ng-if="ctrl.loading">
    <oui-loader inline="true"></oui-loader>
</div>
```

For the use we make of it, `.oui-loader__container` will be more useful with a `margin: auto`. 
And we could replace all of these by:

```
<oui-loader data-ng-if="ctrl.loading"></oui-loader>
```

It will not impact the inline one