### PR TITLE
fix(oui-button): disable state when icon only

### DIFF
--- a/packages/oui-button/README.md
+++ b/packages/oui-button/README.md
@@ -18,103 +18,94 @@ oui-button is a package which provide styles for the button component.
 * The min-width is set to 195px and the max-width is set to 300px. If the translation is longer than that, find a another translation or the bouton will be transform in a link (without border).
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_primary">
-    Primary Button
+<button class="oui-button oui-button_primary">
+  Primary Button
+</button>
+<button class="oui-button oui-button_primary oui-button_icon-right">
+  Button Icon right
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_primary">
+    Primary Button Full width
   </button>
-  <button class="oui-button oui-button_primary oui-button_icon-right">
-    Button Icon right
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_icon-right oui-button_primary">
+    Primary Full width Icon right
     <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
   </button>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_primary">
-      Primary Button Full width
-    </button>
-  </div>
-    <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_icon-right oui-button_primary">
-      Primary Full width Icon right
-      <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
-    </button>
-  </div>
 </div>
 ```
 
 #### Disabled Primary Action Button
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_primary" disabled>
-    Primary Button
+<button class="oui-button oui-button_primary" disabled>
+  Primary Button
+</button>
+<button class="oui-button oui-button_primary oui-button_icon-right" disabled>
+  Button Icon right
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_primary" disabled>
+    Primary Button Full width
   </button>
-  <button class="oui-button oui-button_primary oui-button_icon-right" disabled>
-    Button Icon right
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_icon-right oui-button_primary" disabled>
+    Primary Full width Icon right
     <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
   </button>
-   <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_primary" disabled>
-      Primary Button Full width
-    </button>
-  </div>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_icon-right oui-button_primary" disabled>
-      Primary Full width Icon right
-      <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
-    </button>
-  </div>
 </div>
 ```
 
 ### Secondary Action Button
 
 Multiple secondary action buttons can be found on a page.
-  
+
 ```html:preview
-<div>
-  <button class="oui-button oui-button_secondary">
-    Secondary Button
+<button class="oui-button oui-button_secondary">
+  Secondary Button
+</button>
+  <button class="oui-button oui-button_secondary oui-button_icon-left">
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
+  Button Icon left
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_secondary">
+    Secondary Button Full width
   </button>
-    <button class="oui-button oui-button_secondary oui-button_icon-left">
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_icon-left oui-button_secondary">
     <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
-    Button Icon left
+    Secondary Full width Icon left
   </button>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_secondary">
-      Secondary Button Full width
-    </button>
-  </div>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_icon-left oui-button_secondary">
-      <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
-      Secondary Full width Icon left
-    </button>
-  </div>  
 </div>
 ```
 
 #### Disabled Secondary Action Button
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_secondary" disabled>
-    Secondary Button
+<button class="oui-button oui-button_secondary" disabled>
+  Secondary Button
+</button>
+  <button class="oui-button oui-button_secondary oui-button_icon-left" disabled>
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
+  Button Icon left
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_secondary" disabled>
+    Secondary Button Full width
   </button>
-    <button class="oui-button oui-button_secondary oui-button_icon-left" disabled>
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_icon-left oui-button_secondary" disabled>
     <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
-    Button Icon left
+    Secondary Full width Icon left
   </button>
-  
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_secondary" disabled>
-      Secondary Button Full width
-    </button>
-  </div>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_icon-left oui-button_secondary" disabled>
-      <i class="oui-icon oui-icon_circle oui-icon-chevron-left" aria-hidden="true"></i>
-      Secondary Full width Icon left
-    </button>
-  </div>
 </div>
 ```
 ### Dropdown Button
@@ -122,115 +113,132 @@ Actions grouped under a Dropdown button.  On click, a panel slides down to displ
 * Chevron points down when the menu is open.
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_dropdown">
-    Dropdown Button
-    <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
-  </button>
-</div>
+<button class="oui-button oui-button_dropdown">
+  Dropdown Button
+  <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
+</button>
 ```
 #### Disabled Dropdown Button
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_dropdown" disabled>
-    Dropdown Button
-    <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
-  </button>
-</div>
+<button class="oui-button oui-button_dropdown" disabled>
+  Dropdown Button
+  <i class="oui-icon oui-icon-chevron-down" aria-hidden="true"></i>
+</button>
 ```
 
 ### Link Button
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_link">
-    Button link
-  </button>
-  <button class="oui-button oui-button_link oui-button_icon-left">
+<button class="oui-button oui-button_link">
+  Button link
+</button>
+<button class="oui-button oui-button_link oui-button_icon-left">
+  <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
+  Button link Icon left
+</button>
+<button class="oui-button oui-button_link oui-button_icon-right">
+  Button link Icon right
+  <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_link oui-button_icon-left">
     <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
-    Button link Icon left
+    Button link Full width Icon left
   </button>
-  <button class="oui-button oui-button_link oui-button_icon-right">
-    Button link Icon right
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_full-width oui-button_link oui-button_icon-right">
+    Button link Full width Icon right
     <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
   </button>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_link oui-button_icon-left">
-      <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
-      Button link Full width Icon left
-    </button>
-  </div>
-    <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_full-width oui-button_link oui-button_icon-right">
-      Button link Full width Icon right
-      <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
-    </button>
-  </div>
 </div>
 ```
 
 #### Disabled Link Button
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_link" disabled>
-    Button link
-  </button>
-  <button class="oui-button oui-button_link oui-button_icon-left" disabled>
+<button class="oui-button oui-button_link" disabled>
+  Button link
+</button>
+<button class="oui-button oui-button_link oui-button_icon-left" disabled>
+  <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
+  Button link Icon left
+</button>
+<button class="oui-button oui-button_link oui-button_icon-right" disabled>
+  Button link Icon right
+  <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_link oui-button_full-width oui-button_icon-left" disabled>
     <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
-    Button link Icon left
+    Button link Full width Icon left
   </button>
-  <button class="oui-button oui-button_link oui-button_icon-right" disabled>
-    Button link Icon right
+</div>
+<div style="display: inline-block; width: 300px">
+  <button class="oui-button oui-button_link oui-button_full-width oui-button_icon-right" disabled>
+    Button link Full width Icon right
     <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
   </button>
-      <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_link oui-button_full-width oui-button_icon-left" disabled>
-      <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
-      Button link Full width Icon left
-    </button>
-  </div>
-  <div style="display: inline-block; width: 300px">
-    <button class="oui-button oui-button_link oui-button_full-width oui-button_icon-right" disabled>
-      Button link Full width Icon right
-      <i class="oui-icon oui-icon-chevron-right" aria-hidden="true"></i>
-    </button>
-  </div>
 </div>
 ```
 
 ### Small width
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_primary oui-button_small-width">
-    OK
-  </button>
-  <button class="oui-button oui-button_secondary oui-button_small-width">
-    OK
-  </button>
-  <button class="oui-button oui-button_secondary oui-button_icon-only oui-button_small-width">
-    <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
-  </button>
-</div>
+<button class="oui-button oui-button_primary oui-button_small-width">
+  OK
+</button>
+<button class="oui-button oui-button_secondary oui-button_small-width">
+  OK
+</button>
+<button class="oui-button oui-button_secondary oui-button_icon-only oui-button_small-width">
+  <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
+</button>
+```
+
+#### Disabled Small width
+
+```html:preview
+<button class="oui-button oui-button_primary oui-button_small-width" disabled>
+  OK
+</button>
+<button class="oui-button oui-button_secondary oui-button_small-width" disabled>
+  OK
+</button>
+<button class="oui-button oui-button_secondary oui-button_icon-only oui-button_small-width" disabled>
+  <i class="oui-icon oui-icon-chevron-left" aria-hidden="true"></i>
+</button>
 ```
 
 ### Large height
 
 ```html:preview
-<div>
-  <button class="oui-button oui-button_primary oui-button_large-height">
-    Primary Button
-  </button>
-  <button class="oui-button oui-button_secondary oui-button_large-height">
-    Secondary Button
-  </button>
-  <button class="oui-button oui-button_primary oui-button_icon-right oui-button_large-height">
-    Button Icon right
-    <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
-  </button>
-</div>
+<button class="oui-button oui-button_primary oui-button_large-height">
+  Primary Button
+</button>
+<button class="oui-button oui-button_secondary oui-button_large-height">
+  Secondary Button
+</button>
+<button class="oui-button oui-button_primary oui-button_icon-right oui-button_large-height">
+  Button Icon right
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
+```
+
+### Disabled Large height
+
+```html:preview
+<button class="oui-button oui-button_primary oui-button_large-height" disabled>
+  Primary Button
+</button>
+<button class="oui-button oui-button_secondary oui-button_large-height" disabled>
+  Secondary Button
+</button>
+<button class="oui-button oui-button_primary oui-button_icon-right oui-button_large-height" disabled>
+  Button Icon right
+  <i class="oui-icon oui-icon_circle oui-icon-chevron-right" aria-hidden="true"></i>
+</button>
 ```
 
 ## Mixins

--- a/packages/oui-button/_mixins.less
+++ b/packages/oui-button/_mixins.less
@@ -167,7 +167,8 @@
   .button-icon-base(
     @icon-selector,
     @icon-size: @oui-button-icon-icon-size,
-    @icon-color: @oui-button-icon-icon-color
+    @icon-color: @oui-button-icon-icon-color,
+    @icon-color_disabled: @oui-button-icon-right-icon-color_disabled
   ) {
 
     .@{icon-selector} {
@@ -184,6 +185,15 @@
     .@{icon-selector}_circle::before {
       background: @icon-color;
       font-size: ~"calc(@{icon-size} / 2)";
+    }
+
+    &:disabled .@{icon-selector}::before {
+      color: @icon-color_disabled;
+    }
+
+    &:disabled .@{icon-selector}_circle::before {
+      background: @icon-color_disabled;
+      color: @oui-color-concrete;
     }
   }
 
@@ -203,15 +213,6 @@
       line-height: 2;
       text-indent: 2px;
     }
-
-    &:disabled .@{icon-selector}::before {
-      color: @icon-color_disabled;
-    }
-
-    &:disabled .@{icon-selector}_circle::before {
-      background: @icon-color_disabled;
-      color: @oui-color-concrete;
-    }
   }
 
   .button-icon-left(
@@ -229,15 +230,6 @@
     .@{icon-selector}_circle::before {
       line-height: 2;
       text-indent: -2px;
-    }
-
-    &:disabled .@{icon-selector}::before {
-      color: @icon-color_disabled;
-    }
-
-    &:disabled .@{icon-selector}_circle::before {
-      background: @icon-color_disabled;
-      color: @oui-color-concrete;
     }
   }
 

--- a/packages/oui-input-group/README.md
+++ b/packages/oui-input-group/README.md
@@ -81,6 +81,16 @@ oui-input-group is a package which provide styles to group inputs together.
     <i class="oui-icon oui-icon-add" aria-hidden="true"></i>
   </button>
 </div>
+
+<div class="oui-input-group oui-input-group_numeric">
+  <button class="oui-button oui-button_icon-only oui-button_small-width" type="button" disabled>
+    <i class="oui-icon oui-icon-remove" aria-hidden="true"></i>
+  </button>
+  <input class="oui-input oui-input_number" type="number" disabled>
+  <button class="oui-button oui-button_icon-only oui-button_small-width" type="button" disabled>
+    <i class="oui-icon oui-icon-add" aria-hidden="true"></i>
+  </button>
+</div>
 ```
 
 ## Mixins


### PR DESCRIPTION
Signed-off-by: Jimmy Fortin <jimmy.fortin@corp.ovh.com>

Demo: 
- [oui-button](http://dev_fix_oui_button_icon_only.ui-kit.ovh/#!/ovh-ui-kit/button)
- [oui-input-group](http://dev_fix_oui_button_icon_only.ui-kit.ovh/#!/ovh-ui-kit/input-group)

The icon on `oui-button_icon-only` modifier was kept black and was not grayed out. 