### PR TITLE
feat(build): assume unchanged generated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,15 @@
     "build": "rimraf dist && npm run build:icons && npm run build:less",
     "fix": "stylefmt -r packages",
     "lint": "stylelint --syntax less 'packages/**/*.less'",
-    "preversion": "npm build",
-    "postversion": "git push && git push --tags"
+    "preversion": "npm run no-assume-unchanged:generated && npm build",
+    "postversion": "npm run assume-unchanged:generated && git push && git push --tags",
+    "assume-unchanged:generated-icons-list": "git update-index --assume-unchanged packages/oui-icons/_icons.less",
+    "assume-unchanged:generated-icons-dist": "cd dist && git ls-files -z | xargs -0 git update-index --assume-unchanged",
+    "assume-unchanged:generated": "npm run assume-unchanged:generated-icons-list && npm run assume-unchanged:generated-icons-dist",
+    "no-assume-unchanged:generated-icons-list": "git update-index --no-assume-unchanged packages/oui-icons/_icons.less",
+    "no-assume-unchanged:generated-icons-dist": "cd dist && git ls-files -z | xargs -0 git update-index --no-assume-unchanged",
+    "no-assume-unchanged:generated": "npm run no-assume-unchanged:generated-icons-list && npm run no-assume-unchanged:generated-icons-dist",
+    "install": "npm run assume-unchanged:generated"
   },
   "dependencies": {
     "less-plugin-remcalc": "^0.0.1"


### PR DESCRIPTION
6 new tasks have been added to the package.json to be able to hide/show dist's files and the generated `packages/icons/_icons.less` from their changes (see `git status` here) after a dev has build the library. 

Because we don't have yet a place to put our dist and versionned source code we need to store the dist's result inside this repository. Also, we want the hide changes for those files since our CI system will create releases for us, instead to let the dev doing it by himself.

**Note:** This method will be reused by `ovh-ui-angular` and `ovh-documentation-toolkit`