### PR TITLE
fix(oui-modal): display modal loader over all elements

### DIFF
--- a/packages/oui-modal/_mixins.less
+++ b/packages/oui-modal/_mixins.less
@@ -93,6 +93,7 @@
     }
 
     &__loader {
+      z-index: 1080;
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
This is a fix to display loader background over ui-select and oui-message