### PR TITLE
chore(oui-calendar): bump version of flatpickr to v4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "stylelint": "^8.4.0"
   },
   "peerDependencies": {
-    "flatpickr": "4.4.4"
+    "flatpickr": "4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,5 @@
     "rimraf": "^2.5.4",
     "stylefmt": "^6.0.0",
     "stylelint": "^8.4.0"
-  },
-  "peerDependencies": {
-    "flatpickr": "4.5.0"
   }
 }


### PR DESCRIPTION
https://github.com/flatpickr/flatpickr/releases/tag/v4.5.0
Resolves the logs `Error{}` when launching the unit tests