### PR TITLE
fix: enable woff2 loading

### DIFF
--- a/packages/oui-icons/fonts.less
+++ b/packages/oui-icons/fonts.less
@@ -1,10 +1,10 @@
 @font-face {
-  font-family: 'Oui Icons';
+  font-family: "Oui Icons";
   font-style: normal;
   font-weight: 400;
-  src:  url("@{oui-icon-dist-folder}/icons.eot?#iefix&v=@{oui-version}") format("embedded-opentype"),
-    url("@{oui-icon-dist-folder}/icons.woff?v=@{oui-version}") format("woff"),
+  src: url("@{oui-icon-dist-folder}/icons.eot?#iefix&v=@{oui-version}") format("embedded-opentype"),
     url("@{oui-icon-dist-folder}/icons.woff2?v=@{oui-version}") format("woff2"),
+    url("@{oui-icon-dist-folder}/icons.woff?v=@{oui-version}") format("woff"),
     url("@{oui-icon-dist-folder}/icons.ttf?v=@{oui-version}") format("truetype"),
     url("@{oui-icon-dist-folder}/icons.svg?#icons&v=@{oui-version}") format("svg");
 }

--- a/packages/oui-typography/fonts.less
+++ b/packages/oui-typography/fonts.less
@@ -5,8 +5,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-ExtraLight"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLight.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLight.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLight.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLight.woff") format("woff");
 }
 
 @font-face {
@@ -16,8 +16,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-ExtraLightIt"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLightIt.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLightIt.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLightIt.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/extra-light/SourceSansPro-ExtraLightIt.woff") format("woff");
 }
 
 @font-face {
@@ -27,8 +27,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-Light"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-Light.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-Light.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-Light.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-Light.woff") format("woff");
 }
 
 @font-face {
@@ -38,8 +38,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-LightIt"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-LightIt.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-LightIt.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-LightIt.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/light/SourceSansPro-LightIt.woff") format("woff");
 }
 
 @font-face {
@@ -49,8 +49,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-Regular"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-Regular.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-Regular.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-Regular.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-Regular.woff") format("woff");
 }
 
 @font-face {
@@ -60,8 +60,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-It"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-It.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-It.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-It.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/regular/SourceSansPro-It.woff") format("woff");
 }
 
 @font-face {
@@ -71,8 +71,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-Semibold"),
     local("Source Sans Pro Semibold"),
-    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-Semibold.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-Semibold.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-Semibold.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-Semibold.woff") format("woff");
 }
 
 @font-face {
@@ -82,8 +82,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-SemiboldIt"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-SemiboldIt.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-SemiboldIt.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-SemiboldIt.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/semibold/SourceSansPro-SemiboldIt.woff") format("woff");
 }
 
 @font-face {
@@ -93,8 +93,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-Bold"),
     local("Source Sans Pro Bold"),
-    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-Bold.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-Bold.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-Bold.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-Bold.woff") format("woff");
 }
 
 @font-face {
@@ -104,8 +104,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-BoldIt"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-BoldIt.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-BoldIt.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-BoldIt.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/bold/SourceSansPro-BoldIt.woff") format("woff");
 }
 
 @font-face {
@@ -115,8 +115,8 @@
   font-stretch: normal;
   src: local("SourceSansPro-Black"),
     local("Source Sans Pro Black"),
-    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-Black.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-Black.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-Black.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-Black.woff") format("woff");
 }
 
 @font-face {
@@ -126,6 +126,6 @@
   font-stretch: normal;
   src: local("SourceSansPro-BlackIt"),
     local("Source Sans Pro"),
-    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-BlackIt.woff") format("woff"),
-    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-BlackIt.woff2") format("woff2");
+    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-BlackIt.woff2") format("woff2"),
+    url("@{oui-font-source-sans-pro-folder}/black/SourceSansPro-BlackIt.woff") format("woff");
 }


### PR DESCRIPTION
To be loaded first, the WOFF2 declaration must be placed above WOFF.

Currently the WOFF2 fonts are never loaded... the modern browsers respect the order priority in `url()` (see ["Note" section](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization?hl=en#format_selection))

This small fix will increase our webperf on all projects using ui-kit 👌