### PR TITLE
fix(oui-criteria-adder): set padding on four sides

### DIFF
--- a/packages/oui-criteria-adder/criteria-adder.less
+++ b/packages/oui-criteria-adder/criteria-adder.less
@@ -43,6 +43,5 @@
 
   form {
     padding: rem-calc(20);
-    padding-bottom: 0;
   }
 }


### PR DESCRIPTION
## Restore `oui-criteria-adder` paddings.

### Description of the Change

d155c84 — fix(oui-criteria-adder): set padding on four sides

### Benefits

capture before:
![capture-before](https://user-images.githubusercontent.com/428384/43471403-32199c44-94eb-11e8-86f4-ed834c00da0c.png)

capture after:
![capture-after](https://user-images.githubusercontent.com/428384/43471412-3754dc96-94eb-11e8-9dbd-e09f85e6f336.png)

/cc @jleveugle @Jisay @frenautvh @cbourgois @AxelPeter 
