### PR TITLE
feat(oui-select-picker): default and light templates

### DIFF
--- a/packages/oui-select-picker/_mixins.less
+++ b/packages/oui-select-picker/_mixins.less
@@ -6,53 +6,6 @@
   .select-picker(
     @selector
   ) {
-    #oui > .radio(
-      @selector
-    );
-
-    #oui > .radio-thumbnail(
-      @selector
-    );
-
-    &__picture-container {
-      display: block;
-      max-width: @oui-select-picker-padding * 2;
-      position: absolute;
-      right: @oui-select-picker-padding;
-      text-align: center;
-      top: @oui-select-picker-padding - rem-calc(5);
-      width: 10%;
-
-      .@{selector}__picture {
-        display: inline-block;
-        max-width: 100%;
-      }
-
-      & + .@{selector}__label {
-        padding-right: ~"calc(10% + 1rem)";
-
-        & + .@{selector}__section {
-          margin-top: rem-calc(14);
-        }
-      }
-    }
-
-    &__value {
-      color: @oui-select-picker-label-color;
-      display: inline-block;
-      opacity: 0.5;
-      padding-bottom: @oui-select-picker-value-padding;
-      padding-top: @oui-select-picker-value-padding;
-      width: 100%;
-    }
-
-    &__input:checked ~ .@{selector}__label-container,
-    &__input:disabled ~ .@{selector}__label-container {
-      .@{selector}__value {
-        opacity: 1;
-      }
-    }
-
     &__input:disabled ~ .@{selector}__label-container {
       .@{selector}__value {
         color: @oui-select-picker-label-color-disabled;
@@ -107,29 +60,6 @@
         & > i {
           opacity: 1;
         }
-      }
-    }
-
-    // sub components exceptions
-    .oui-select,
-    .oui-ui-select-container {
-      margin-bottom: 0;
-    }
-
-    .oui-select > .oui-icon {
-      background-color: inherit;
-    }
-
-    .oui-ui-select-container {
-      .ui-select-match {
-        margin-bottom: 0;
-        text-align: left;
-        width: 100%;
-      }
-
-      .ui-select-match,
-      .ui-select-choices {
-        min-width: 100%;
       }
     }
   }

--- a/packages/oui-select-picker/_normalize.less
+++ b/packages/oui-select-picker/_normalize.less
@@ -2,6 +2,14 @@
 
 #oui {
   .select-picker-normalize() {
+    #oui > .radio(
+      @oui-select-picker-selector
+    );
+
+    #oui > .radio-thumbnail(
+      @oui-select-picker-selector
+    );
+
     &__label-container {
       font-weight: inherit;
       cursor: pointer;
@@ -14,6 +22,68 @@
 
     &__label {
       #oui > .base-font();
+    }
+
+    &__picture-container {
+      display: block;
+      max-width: @oui-select-picker-padding * 2;
+      position: absolute;
+      right: @oui-select-picker-padding;
+      text-align: center;
+      top: @oui-select-picker-padding - rem-calc(5);
+      width: 10%;
+
+      .@{oui-select-picker-selector}__picture {
+        display: inline-block;
+        max-width: 100%;
+      }
+
+      & + .@{oui-select-picker-selector}__label {
+        padding-right: ~"calc(10% + 1rem)";
+
+        & + .@{oui-select-picker-selector}__section {
+          margin-top: rem-calc(14);
+        }
+      }
+    }
+
+    &__value {
+      color: @oui-select-picker-label-color;
+      display: inline-block;
+      opacity: 0.5;
+      padding-bottom: @oui-select-picker-value-padding;
+      padding-top: @oui-select-picker-value-padding;
+      width: 100%;
+    }
+
+    &__input:checked ~ .@{oui-select-picker-selector}__label-container,
+    &__input:disabled ~ .@{oui-select-picker-selector}__label-container {
+      .@{oui-select-picker-selector}__value {
+        opacity: 1;
+      }
+    }
+
+    // sub components exceptions
+    .oui-select,
+    .oui-ui-select-container {
+      margin-bottom: 0;
+    }
+
+    .oui-select > .oui-icon {
+      background-color: inherit;
+    }
+
+    .oui-ui-select-container {
+      .ui-select-match {
+        margin-bottom: 0;
+        text-align: left;
+        width: 100%;
+      }
+
+      .ui-select-match,
+      .ui-select-choices {
+        min-width: 100%;
+      }
     }
   }
 }

--- a/packages/oui-select-picker/select-picker.less
+++ b/packages/oui-select-picker/select-picker.less
@@ -5,6 +5,13 @@
   @oui-select-picker-selector: oui-select-picker;
 
   #oui > .select-picker-normalize();
-  #oui > .select-picker(@oui-select-picker-selector);
   #oui > .select-picker-status();
+
+  &_default {
+    #oui > .select-picker(@oui-select-picker-selector);
+  }
+
+  &_light {
+    #oui > .radio-thumbnail-light(@oui-select-picker-selector);
+  }
 }


### PR DESCRIPTION
## Add default and light templates for oui-select-picker
### Description of the Change
Split available templates for oui-select-picker in two ones : 
- Default (it will contain actual template)
- Light (apply the radio thumbnail-light style to component)

Styles are changeable through a new "variant" property, in this way, adding a new template is possible if required.

(Need the merge of the following PR in https://github.com/ovh-ux/ovh-ui-angular/pull/269)