### PR TITLE
fix(oui-datagrid): fix sticky columns

### DIFF
--- a/packages/oui-datagrid/_mixins.less
+++ b/packages/oui-datagrid/_mixins.less
@@ -203,11 +203,11 @@
     position: relative;
 
     &_sticky-checkbox {
-      padding-left: @oui-datagrid-checkbox-column-width - 1px;
+      padding-left: @oui-datagrid-checkbox-column-width;
     }
 
     &_sticky-actions {
-      padding-right: @oui-datagrid-action-column-width - 1px;
+      padding-right: @oui-datagrid-action-column-width;
     }
   }
 


### PR DESCRIPTION
Columns next to sticky columns are cropped. This fix the cropping by removing the useless calculation.