### PR TITLE
fix: fix default style for custom tags

### DIFF
--- a/packages/oui-collapsible/_normalize.less
+++ b/packages/oui-collapsible/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-collapsible {
+  display: block;
+}
+
 #oui {
   .collapsible-normalize() {
     #oui > .base-font();

--- a/packages/oui-criteria-adder/_normalize.less
+++ b/packages/oui-criteria-adder/_normalize.less
@@ -1,0 +1,3 @@
+oui-criteria-adder {
+  display: inline-block;
+}

--- a/packages/oui-criteria-adder/criteria-adder.less
+++ b/packages/oui-criteria-adder/criteria-adder.less
@@ -1,4 +1,5 @@
 @import '../oui-button/_variables';
+@import './_normalize';
 
 .oui-criteria-adder {
   display: inline-block;

--- a/packages/oui-datagrid/_normalize.less
+++ b/packages/oui-datagrid/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-datagrid {
+  display: block;
+}
+
 #oui {
   .datagrid-normalize() {
     #oui > .base-font();

--- a/packages/oui-field/_normalize.less
+++ b/packages/oui-field/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-field {
+  display: block;
+}
+
 #oui {
   .field-normalize() {
     #oui > .base-font();

--- a/packages/oui-guide-menu/guide-menu.less
+++ b/packages/oui-guide-menu/guide-menu.less
@@ -9,17 +9,26 @@
   padding: 0;
   font: inherit;
   cursor: pointer;
-  outline: inherit;
   white-space: nowrap;
 
+  &:focus {
+    outline-width: 1px;
+    outline-style: dotted;
+    outline-color: initial;
+    outline-offset: -2px;
+  }
+
   &__icon {
+    display: inline-block;
     vertical-align: middle;
+    font-size: 0;
   }
 
   &__text {
     margin-left: 10px;
     font-size: @oui-guide-button-font-size;
     font-weight: 600;
+    vertical-align: middle;
   }
 
   @media screen and (max-width: (@oui-responsive-breakpoint-phone - 1)) {

--- a/packages/oui-header-tabs/header-tabs.less
+++ b/packages/oui-header-tabs/header-tabs.less
@@ -55,6 +55,13 @@
     & > a {
       color: @oui-color-sapphire;
       text-decoration: none;
+
+      &:focus {
+        outline-width: 1px;
+        outline-style: dotted;
+        outline-color: initial;
+        outline-offset: -2px;
+      }
     }
 
     & > a,

--- a/packages/oui-input-group/_normalize.less
+++ b/packages/oui-input-group/_normalize.less
@@ -1,0 +1,5 @@
+oui-clipboard,
+oui-numeric,
+oui-search {
+  display: block;
+}

--- a/packages/oui-input-group/input-group.less
+++ b/packages/oui-input-group/input-group.less
@@ -1,6 +1,7 @@
 @import '../oui-animation/_mixins';
 @import '../oui-typography/_mixins';
 @import './_mixins';
+@import './_normalize';
 
 oui-clipboard { display: block; }
 

--- a/packages/oui-message/_normalize.less
+++ b/packages/oui-message/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-message {
+  display: block;
+}
+
 #oui {
   .message-normalize() {
     #oui > .base-font();

--- a/packages/oui-page-header/_normalize.less
+++ b/packages/oui-page-header/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-page-header {
+  display: block;
+}
+
 #oui {
   .page-header-normalize() {
     #oui > .base-font();

--- a/packages/oui-pagination/_normalize.less
+++ b/packages/oui-pagination/_normalize.less
@@ -1,0 +1,3 @@
+oui-pagination {
+  display: block;
+}

--- a/packages/oui-pagination/pagination.less
+++ b/packages/oui-pagination/pagination.less
@@ -1,5 +1,6 @@
 @import "../oui-button/_mixins";
 @import "./_mixins";
+@import "./_normalize";
 
 .oui-pagination {
   @oui-button-selector: oui-button;

--- a/packages/oui-radio-toggle-group/_normalize.less
+++ b/packages/oui-radio-toggle-group/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-radio-toggle-group {
+  display: block;
+}
+
 #oui {
   .radio-toggle-normalize() {
     &__label{

--- a/packages/oui-radio/_normalize.less
+++ b/packages/oui-radio/_normalize.less
@@ -1,5 +1,10 @@
 @import '../oui-typography/_mixins';
 
+oui-radio,
+oui-radio-group {
+  display: block;
+}
+
 #oui {
   .radio-normalize() {
     &__label-container {

--- a/packages/oui-select-picker/_normalize.less
+++ b/packages/oui-select-picker/_normalize.less
@@ -1,5 +1,10 @@
 @import '../oui-typography/_mixins';
 
+oui-select-picker,
+oui-select-picker-section {
+  display: block;
+}
+
 #oui {
   .select-picker-normalize() {
     &__label-container {

--- a/packages/oui-select/_normalize.less
+++ b/packages/oui-select/_normalize.less
@@ -1,5 +1,9 @@
 @import '../oui-typography/_mixins';
 
+oui-select {
+  display: block;
+}
+
 #oui {
   .select-normalize() {
     #oui > .base-font();

--- a/packages/oui-skeleton/_normalize.less
+++ b/packages/oui-skeleton/_normalize.less
@@ -1,0 +1,3 @@
+oui-skeleton {
+  display: block;
+}

--- a/packages/oui-skeleton/skeleton.less
+++ b/packages/oui-skeleton/skeleton.less
@@ -1,5 +1,6 @@
 @import './_variables';
 @import './_mixins';
+@import './_normalize';
 
 .oui-skeleton {
   min-height: @oui-skeleton-height;

--- a/packages/oui-spinner/_normalize.less
+++ b/packages/oui-spinner/_normalize.less
@@ -1,0 +1,3 @@
+oui-spinner {
+  display: inline-block;
+}

--- a/packages/oui-spinner/spinner.less
+++ b/packages/oui-spinner/spinner.less
@@ -1,4 +1,5 @@
 @import './_variables';
+@import './_normalize';
 
 .oui-spinner {
   display: inline-block;

--- a/packages/oui-switch/_normalize.less
+++ b/packages/oui-switch/_normalize.less
@@ -1,0 +1,3 @@
+oui-switch {
+  display: inline-block;
+}

--- a/packages/oui-switch/switch.less
+++ b/packages/oui-switch/switch.less
@@ -2,6 +2,7 @@
 @import "../oui-animation/_mixins";
 @import "../oui-color/_variables";
 @import "./_mixins";
+@import "./_normalize";
 @import "./_variables";
 
 .oui-switch {

--- a/packages/oui-textarea/_normalize.less
+++ b/packages/oui-textarea/_normalize.less
@@ -1,6 +1,10 @@
 @import '../oui-input/_normalize';
 @import '../oui-typography/_mixins';
 
+oui-textarea {
+  display: block;
+}
+
 #oui {
   .textarea-normalize() {
     #oui > .base-font();


### PR DESCRIPTION
Some of our custom tags haven't default style. This could lead to have block elements in inline elements.
It could help older browsers to know what to do with these unknown tags.