### PR TITLE
fix(oui-status): set border to none when it's used on a button element

### DIFF
--- a/packages/oui-status/status.less
+++ b/packages/oui-status/status.less
@@ -6,6 +6,7 @@
 
   #oui > .status-normalize();
 
+  border: none;
   border-radius: 50px;
   color: @oui-color-sapphire;
   display: inline-block;


### PR DESCRIPTION
## Set border to none when it's used on a button element

### Description of the Change

0e83f86 - fix(oui-status): set border to none when it's used on a button element 

### Example

Some part of the application is applying `oui-status` directly on `<button>` element which ends with this result:

![capture](https://user-images.githubusercontent.com/428384/48087885-d2d74200-e200-11e8-9a82-3e22356189ad.png)

ref: https://github.com/ovh-ux/ovh-module-exchange/blob/master/src/exchange/domain/domain.html#L116

/cc @AxelPeter @FredericEspiau @JeremyDec @euhmeuh 