### PR TITLE
fix(oui-radio): light background color

### DIFF
--- a/packages/oui-radio/_mixins.less
+++ b/packages/oui-radio/_mixins.less
@@ -401,7 +401,7 @@
     @background: @oui-thumbnail-background-light,
     @background-hover: @oui-thumbnail-background-light_hover,
     @background_disabled: @oui-thumbnail-background-light,
-    @background-checked_disabled: @oui-thumbnail-background_disabled,
+    @background-checked_disabled: @oui-thumbnail-background-light,
     @border-size: @oui-thumbnail-border-size
   ) {
     .@{selector}__label-container {


### PR DESCRIPTION
Close MBE-185

### Requirements

Background color for light radio button should be white (to match with that of select-picker) when disabled and checked

## Radio light mode background


### Description of the Change

The background color has been fixed to match that of select-picker