### PR TITLE
fix(oui-navbar): center aside links

### DIFF
--- a/packages/oui-navbar/_mixins.less
+++ b/packages/oui-navbar/_mixins.less
@@ -62,6 +62,7 @@
     display: @display;
     flex-direction: row;
     align-items: center;
+    justify-content: center;
     padding: @padding;
     position: relative;
     text-decoration: none;


### PR DESCRIPTION
## 📏 Center aside links 🔗

### Description of the Change

d59e93c — fix(oui-navbar): center aside links

### Benefits

Before:

![screenshot-navbar-before](https://user-images.githubusercontent.com/428384/51072247-f1711380-165d-11e9-8c12-414b71f96a1f.png)

After:

![screenshot-navbar-after](https://user-images.githubusercontent.com/428384/51072250-f766f480-165d-11e9-814f-64bbe1d9f556.png)
