### PR TITLE
fix: remove unneeded user-select

### DIFF
--- a/packages/oui-checkbox/_mixins.less
+++ b/packages/oui-checkbox/_mixins.less
@@ -90,7 +90,6 @@
       min-height: @min-height;
       margin: 0;
       cursor: pointer;
-      user-select: none;
     }
 
     &__label {
@@ -105,7 +104,6 @@
       color: @font-color;
       display: inline-block;
       width: 100%;
-      user-select: none;
     }
 
     &__description:not(:last-child) {

--- a/packages/oui-list/_mixins.less
+++ b/packages/oui-list/_mixins.less
@@ -29,7 +29,6 @@
       color: @title-color;
       font-weight: @oui-font-semibold;
       font-size: @title-font-size;
-      user-select: none;
     }
 
     &__header:not(a) {

--- a/packages/oui-popover/popover.less
+++ b/packages/oui-popover/popover.less
@@ -23,7 +23,6 @@
   transition-duration: @oui-popover-transition-duration;
   transition-timing-function: @oui-popover-transition-animation;
   z-index: -1;
-  user-select: none;
   pointer-events: none;
 
   &__arrow {

--- a/packages/oui-radio/_mixins.less
+++ b/packages/oui-radio/_mixins.less
@@ -160,8 +160,6 @@
     &__label::before,
     &__label::after {
       #oui > .animate();
-
-      user-select: none;
     }
 
     &__label-container {


### PR DESCRIPTION
## Title of the Pull Requests
feat: remove unneeded user-select

### Description of the Change
As we are willing to use complex content inside these components, it might be interesting for the user to be able to select the inner content in order to have various uses (like copy-pasting contents, prices, ...)

However, I kept the `user-select: none` for the components that really don't need to be selected : oui-button, oui-file, oui-tooltip and oui-navbar

### Benefits
User will be able to select content inside these components

### Possible Drawbacks
As a result, it might select the content when not needed (for instance when checking a checkbox)