### PR TITLE
fix(oui-modal): remove loader absolute position

### DIFF
--- a/packages/oui-modal/_mixins.less
+++ b/packages/oui-modal/_mixins.less
@@ -94,10 +94,6 @@
     }
 
     &__loader {
-      z-index: 1080;
-      position: absolute;
-      top: 0;
-      left: 0;
       width: 100%;
       height: 100%;
       display: flex;


### PR DESCRIPTION
## fix(oui-modal): remove loader absolute position

### Description of the Change

b459a92 — fix(oui-modal): remove loader absolute position

/cc @jleveugle @AxelPeter @marie-j 