### PR TITLE
feat(oui-navbar): add dropdown links style

### DIFF
--- a/packages/oui-navbar/navbar.less
+++ b/packages/oui-navbar/navbar.less
@@ -192,7 +192,8 @@
   // Variant for links displayed in main navbar bar
   & > &-list > &-list__item > &-link,
   & > &-list > oui-navbar-main > &-list__item > &-link,
-  & > &-list > oui-navbar-aside > &-list__item > &-link {
+  & > &-list > oui-navbar-aside > &-list__item > &-link,
+  &-dropdown > &-link {
     #oui > .navbar-link(
       @min-height: @oui-navbar-height,
       @line-height: @oui-navbar-line-height,


### PR DESCRIPTION
## Apply default style to links in `oui-navbar-dropdown`


### Description of the Change

Apply default style to `oui-navbar-dropdown` direct child links

### Benefits

Allow to wrap `oui-navbar-dropdown` in HTML elements/components 
