### PR TITLE
perf(oui-typography): font rendering configuration

### DIFF
--- a/packages/oui-icons/fonts.less
+++ b/packages/oui-icons/fonts.less
@@ -5,6 +5,7 @@
   font-family: "Oui Icons";
   font-style: normal;
   font-weight: 400;
+  font-display: block;
   src:
     url("@{oui-icon-dist-folder}/icons.woff2?v=@{oui-version}") format("woff2"),
     url("@{oui-icon-dist-folder}/icons.woff?v=@{oui-version}") format("woff");

--- a/packages/oui-typography/fonts.less
+++ b/packages/oui-typography/fonts.less
@@ -5,6 +5,7 @@
   font-weight: 200;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-ExtraLight"),
     local("Source Sans Pro"),
@@ -17,6 +18,7 @@
   font-weight: 200;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-ExtraLightIt"),
     local("Source Sans Pro"),
@@ -29,6 +31,7 @@
   font-weight: 300;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-Light"),
     local("Source Sans Pro"),
@@ -41,6 +44,7 @@
   font-weight: 300;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-LightIt"),
     local("Source Sans Pro"),
@@ -53,6 +57,7 @@
   font-weight: 400;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-Regular"),
     local("Source Sans Pro"),
@@ -65,6 +70,7 @@
   font-weight: 400;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-It"),
     local("Source Sans Pro"),
@@ -77,6 +83,7 @@
   font-weight: 600;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-Semibold"),
     local("Source Sans Pro Semibold"),
@@ -89,6 +96,7 @@
   font-weight: 600;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-SemiboldIt"),
     local("Source Sans Pro"),
@@ -101,6 +109,7 @@
   font-weight: 700;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-Bold"),
     local("Source Sans Pro Bold"),
@@ -113,6 +122,7 @@
   font-weight: 700;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-BoldIt"),
     local("Source Sans Pro"),
@@ -125,6 +135,7 @@
   font-weight: 900;
   font-style: normal;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-Black"),
     local("Source Sans Pro Black"),
@@ -137,6 +148,7 @@
   font-weight: 900;
   font-style: italic;
   font-stretch: normal;
+  font-display: fallback;
   src:
     local("SourceSansPro-BlackIt"),
     local("Source Sans Pro"),


### PR DESCRIPTION
## Title of the Pull Requests

perf(oui-typography): font rendering configuration

### Description of the Change

A new CSS feature inside @font-face definition is font-display, which permits to set a way of
displaying/awaiting the font-family. 

(see: https://developers.google.com/web/updates/2016/02/font-display)

I arbitrarily choose a font-display:block for "Oui Icons" and font-display:fallback for "Source Sans Pro", but it can be debated.

(FYI, CanIUse support : https://caniuse.com/#feat=css-font-rendering-controls)