### PR TITLE
feat(oui-navbar): truncate if menu title is too long

### DIFF
--- a/packages/oui-navbar/navbar.less
+++ b/packages/oui-navbar/navbar.less
@@ -1,6 +1,7 @@
 @import '../oui/_settings';
 @import '../oui-icons/_variables';
 @import '../oui-responsive/responsive';
+@import '../oui-typography/_mixins';
 @import './_normalize';
 @import './_mixins';
 
@@ -396,6 +397,8 @@
 
     // Title for Header
     &__title {
+      #oui > .text-ellipsis();
+
       line-height: @oui-navbar-menu-title-line-height;
       margin: 0;
       padding: 0;


### PR DESCRIPTION
## Add ellipsis if menu title is too long

### Description of the Change

Add ellipsis if menu title is too long

### Benefits

Avoid having multiple lines menu title

### Related 
- [ ] https://github.com/ovh-ux/ovh-ui-angular/pull/382