### PR TITLE
fix(oui-popover): set white-space to normal

### DIFF
--- a/packages/oui-popover/popover.less
+++ b/packages/oui-popover/popover.less
@@ -24,6 +24,7 @@
   transition-timing-function: @oui-popover-transition-animation;
   z-index: -1;
   pointer-events: none;
+  white-space: normal;
 
   &__arrow {
     background-color: @oui-popover-background-color;


### PR DESCRIPTION
## fix(oui-popover): set white-space to normal

### Description of the Change

6fd6dca — fix(oui-popover): set white-space to normal

ref: 

/cc @jleveugle @marie-j @AxelPeter 
