### PR TITLE
feat(oui-icons): use guides icon in guides menu

### DIFF
--- a/packages/oui-guide-menu/guide-menu.less
+++ b/packages/oui-guide-menu/guide-menu.less
@@ -21,7 +21,6 @@
   &__icon {
     display: inline-block;
     vertical-align: middle;
-    font-size: 0;
   }
 
   &__text {


### PR DESCRIPTION
## Feat/guide menu icon


### Description of the Change

Adapt style to be able to use guides icon in guides menu

### Related
- [ ] https://github.com/ovh-ux/ovh-ui-angular/pull/388