### PR TITLE
docs(readme): remove deprecated link to ovh-ui-kit-documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ to hear from you!
 
 see [CONTRIBUTING](https://github.com/ovh-ux/ovh-ui-kit/blob/master/CONTRIBUTING.md)
 
-And read this [quick start](https://github.com/ovh-ux/ovh-ui-kit-documentation).
-
 ## Related links
 
  * Contribute: [https://github.com/ovh-ux/ovh-ui-kit/blob/master/CONTRIBUTING.md](https://github.com/ovh-ux/ovh-ui-kit/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
# Remove deprecated link to ovh-ui-kit-documentation

### 📝 Documentation

6e75a2e - docs(readme): remove deprecated link to ovh-ui-kit-documentation

### 💥 Breaking Change

module is now named as `@ovh-ux/ui-kit`