### PR TITLE
docs(tabs): set right type to the checked attribute

### DIFF
--- a/packages/components/tabs/README.md
+++ b/packages/components/tabs/README.md
@@ -19,5 +19,5 @@ angular.module('myModule', ['oui.tabs']);
 | `id`          | string    | @?        | yes               | n/a               | n/a       | id attribute of the panel
 | `heading`     | string    | @?        | yes               | n/a               | n/a       | heading text of the tab
 | `aria-label`  | string    | @?        | yes               | n/a               | n/a       | accessibility label
-| `checked`     | booldean  | <?        | yes               | `true`, `false`   | n/a       | check mark flag of the tab
+| `checked`     | boolean   | <?        | yes               | `true`, `false`   | n/a       | check mark flag of the tab
 | `on-active`   | function  | &         | no                | n/a               | n/a       | function called when tab is active


### PR DESCRIPTION
# Set right type to the checked attribute

### 📝 Documentation

3b06a45 - docs(tabs): set right type to the checked attribute