### PR TITLE
fix(select): close others opened select on opening

### DIFF
--- a/packages/components/select/src/js/select.controller.js
+++ b/packages/components/select/src/js/select.controller.js
@@ -2,12 +2,13 @@ import { addBooleanParameter } from '@ovh-ux/ui-kit.core/src/js/component-utils'
 import get from 'lodash/get';
 
 export default class {
-  constructor($attrs, $compile, $element, $scope, $timeout) {
+  constructor($attrs, $compile, $element, $rootScope, $scope, $timeout) {
     'ngInject';
 
     this.$attrs = $attrs;
     this.$compile = $compile;
     this.$element = $element;
+    this.$rootScope = $rootScope;
     this.$scope = $scope;
     this.$timeout = $timeout;
   }
@@ -44,6 +45,10 @@ export default class {
 
     // For focus from oui-field label
     this.unregisterFocus = this.$scope.$on('oui:focus', () => this.$select.setFocus());
+
+    this.$scope.$on('oui-select:closeAll', () => {
+      this.$select.close();
+    });
   }
 
   $onDestroy() {
@@ -61,6 +66,11 @@ export default class {
   }
 
   onUiSelectClick() {
+    // Close others instances of oui-select before opening it
+    if (!this.$select.open) {
+      this.$rootScope.$broadcast('oui-select:closeAll');
+    }
+
     if (!this.$select.focus) {
       this.$select.setFocus();
     }


### PR DESCRIPTION
UK-98

When you open a `oui-select` and click on another one, the previously opened select doesn't close.