### PR TITLE
fix(oui-datagrid): prevent scroll from displaying inside the datagrid

### DIFF
--- a/packages/oui-datagrid/_mixins.less
+++ b/packages/oui-datagrid/_mixins.less
@@ -300,5 +300,6 @@
   .datagrid-overflow-container() {
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
   }
 }


### PR DESCRIPTION
##  Prevent scroll from displaying inside the datagrid

### Description of the Change

Prevent a vertical scroll from being displayed

### Applicable Issues

When adding a `oui-clipboard` the hidden `tooltip` makes the datagrid container overflow with a scroll. this scroll doesn't apply on all datagrid, it excludes the `oui-action-menu`
Example : MSB-31
