### PR TITLE
fix(oui-datagrid): prevent scroll from displaying inside the datagrid

### DIFF
--- a/packages/components/datagrid/src/less/datagrid.less
+++ b/packages/components/datagrid/src/less/datagrid.less
@@ -213,6 +213,7 @@ oui-datagrid {
   &__overflow-container {
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
   }
 
   .oui-datagrid {


### PR DESCRIPTION
A scroll is displayed but not for actions-menu in some cases

Replicate https://github.com/ovh-ux/ovh-ui-kit/pull/432/commits