### PR TITLE
fix(button): set max-width to 100%

### DIFF
--- a/packages/oui-button/_variables.less
+++ b/packages/oui-button/_variables.less
@@ -9,7 +9,7 @@
 @oui-button-font-weight: @oui-font-semibold;
 @oui-button-radius: @oui-global-base-radius;
 @oui-button-min-width: rem-calc(100);
-@oui-button-max-width: rem-calc(320);
+@oui-button-max-width: 100%;
 @oui-button-padding-base: rem-calc(10);
 @oui-button-padding: @oui-button-padding-base rem-calc(20);
 @oui-button-spacing: 0;


### PR DESCRIPTION
MANAGER-2779

Remove the default max-width of `.oui-button` by setting it to `100%`.