### PR TITLE
feat(tile): add transclude for term and actions

### DIFF
--- a/packages/apps/workshop/stories/components/tile.stories.js
+++ b/packages/apps/workshop/stories/components/tile.stories.js
@@ -59,11 +59,7 @@ storiesOf('Components/Tile', module)
     <oui-tile heading="Title" description="Lorem dolor sit amet" loading="$ctrl.loading">
       <oui-tile-definition
         term="Term"
-        description="This is a description">
-      </oui-tile-definition>
-      <oui-tile-definition
-        term="Term">
-        <oui-tile-description>This is a description</oui-tile-description>
+        description="This is a description that use the attribute">
       </oui-tile-definition>
       <oui-tile-definition
         term="Term"
@@ -71,17 +67,31 @@ storiesOf('Components/Tile', module)
         description="This is a description">
       </oui-tile-definition>
       <oui-tile-definition
+        term="Term"
+        description="This is a description with an action menu">
+        <oui-action-menu compact>
+          <oui-action-menu-item>Action 1</oui-action-menu-item>
+        </oui-action-menu>
+      </oui-tile-definition>
+      <oui-tile-definition>
+        <oui-tile-term>Term</oui-tile-term>
+        <oui-tile-description>This is a definition that use transcludes</oui-tile-description>
+        <oui-tile-actions>
+          <oui-dropdown placement="end">
+            <oui-dropdown-trigger text="Actions"></oui-dropdown-trigger>
+            <oui-dropdown-content>
+              <oui-dropdown-item href="#">Action 1</oui-dropdown-item>
+              <oui-dropdown-item href="#">Action 2</oui-dropdown-item>
+              <oui-dropdown-item href="#">Action 3</oui-dropdown-item>
+            </oui-dropdown-content>
+          </oui-dropdown>
+        </oui-tile-actions>
+      </oui-tile-definition>
+      <oui-tile-definition
         term="Progress">
         <oui-tile-description>
           <progress class="oui-progress oui-progress_success" value="10" max="100"></progress>
         </oui-tile-description>
-      </oui-tile-definition>
-      <oui-tile-definition
-        term="Term"
-        description="This is a description">
-        <oui-action-menu compact>
-          <oui-action-menu-item>Action 1</oui-action-menu-item>
-        </oui-action-menu>
       </oui-tile-definition>
     </oui-tile>
     `, {

--- a/packages/components/tile/README.md
+++ b/packages/components/tile/README.md
@@ -31,3 +31,19 @@ angular.module('myModule', ['oui.tile']);
 | `term`            | string   | @?         | yes               | n/a               | n/a       | definition term item
 | `term-popover`    | string   | @?         | yes               | n/a               | n/a       | definition term item popover
 | `description`     | string   | @?         | yes               | n/a               | n/a       | definition description item
+
+### Transclude slots
+
+| Attribute                   | Description
+| ----                        | ----
+| `<oui-title-term>`          | definition term slot, override attribute `term`
+| `<oui-title-description>`   | definition description slot, override attribute `description`
+| `<oui-title-actions>`       | definition actions slot
+
+```html
+<oui-title-definition>
+    <oui-title-term>Term</oui-title-term>
+    <oui-title-description>Descriptions</oui-title-description>
+    <oui-title-actions>Actions</oui-title-actions>
+<oui-title-definition>
+```

--- a/packages/components/tile/src/js/definition/tile-definition.component.js
+++ b/packages/components/tile/src/js/definition/tile-definition.component.js
@@ -10,7 +10,9 @@ export default {
     description: '@?',
   },
   transclude: {
+    actionMenuSlot: '?ouiActionMenu',
+    actionsSlot: '?ouiTileActions',
     descriptionSlot: '?ouiTileDescription',
-    actionSlot: '?ouiActionMenu',
+    termSlot: '?ouiTileTerm',
   },
 };

--- a/packages/components/tile/src/js/definition/tile-definition.controller.js
+++ b/packages/components/tile/src/js/definition/tile-definition.controller.js
@@ -9,7 +9,7 @@ export default class {
   }
 
   $onInit() {
-    this.transcludeAction = this.$transclude.isSlotFilled('actionSlot');
+    this.transcludeActions = this.$transclude.isSlotFilled('actionsSlot') || this.$transclude.isSlotFilled('actionMenuSlot');
   }
 
   $postLink() {

--- a/packages/components/tile/src/js/definition/tile-definition.html
+++ b/packages/components/tile/src/js/definition/tile-definition.html
@@ -1,5 +1,5 @@
 <dl class="oui-tile__definition">
-    <dt class="oui-tile__term">
+    <dt class="oui-tile__term" ng-transclude="termSlot">
         <span ng-bind="::$ctrl.term"></span>
         <button type="button" class="oui-popover-button"
             aria-label="Help"
@@ -12,6 +12,7 @@
     </dd>
 </dl>
 <div class="oui-tile__actions"
-    ng-if="$ctrl.transcludeAction"
-    ng-transclude="actionSlot">
+    ng-if="$ctrl.transcludeActions">
+    <div ng-transclude="actionMenuSlot"></div>
+    <div ng-transclude="actionsSlot"></div>
 </div>

--- a/packages/components/tile/src/js/tile.spec.js
+++ b/packages/components/tile/src/js/tile.spec.js
@@ -15,6 +15,7 @@ describe('ouiTile', () => {
   const getTileButton = element => angular.element(element[0].querySelector('.oui-tile__button'));
   const getTileDefinitionTerm = element => angular.element(element[0].querySelector('.oui-tile__term'));
   const getTileDefinitionDesc = element => angular.element(element[0].querySelector('.oui-tile__description'));
+  const getTileDefinitionActions = element => angular.element(element[0].querySelector('.oui-tile__actions'));
   const getActionMenu = element => angular.element(element[0].querySelector('.oui-tile__actions'));
 
   describe('Component', () => {
@@ -43,8 +44,8 @@ describe('ouiTile', () => {
       const text = 'button text';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button>${text}</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button>${text}</oui-tile-button>
+        </oui-tile>`,
       );
 
       $timeout.flush();
@@ -58,8 +59,8 @@ describe('ouiTile', () => {
       const text = 'button text';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button>${text}</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button>${text}</oui-tile-button>
+        </oui-tile>`,
       );
 
       const button = getTileButton(element);
@@ -70,8 +71,8 @@ describe('ouiTile', () => {
       const text = 'button text';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button>${text}</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button>${text}</oui-tile-button>
+        </oui-tile>`,
       );
 
       const button = getTileButton(element);
@@ -82,8 +83,8 @@ describe('ouiTile', () => {
       const url = 'http://my.url';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button href="${url}">text</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button href="${url}">text</oui-tile-button>
+        </oui-tile>`,
       );
 
       const button = getTileButton(element);
@@ -95,8 +96,8 @@ describe('ouiTile', () => {
       const targetAttr = '_blank';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button href="http://myurl.com" external>text</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button href="http://myurl.com" external>text</oui-tile-button>
+        </oui-tile>`,
       );
 
       const button = getTileButton(element);
@@ -109,8 +110,8 @@ describe('ouiTile', () => {
       const clickSpy = jasmine.createSpy('click');
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button on-click="$ctrl.clickSpy()">text</oui-tile-button>
-                </oui-tile>`, {
+            <oui-tile-button on-click="$ctrl.clickSpy()">text</oui-tile-button>
+        </oui-tile>`, {
           clickSpy,
         },
       );
@@ -122,8 +123,8 @@ describe('ouiTile', () => {
     it('should disable the button', () => {
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button disabled>text</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button disabled>text</oui-tile-button>
+        </oui-tile>`,
       );
 
       expect(getTileButton(element).attr('disabled')).toBe('disabled');
@@ -132,8 +133,8 @@ describe('ouiTile', () => {
     it('should display a disabled button instead of a link', () => {
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-button href="#" disabled>text</oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-button href="#" disabled>text</oui-tile-button>
+        </oui-tile>`,
       );
 
       expect(getTileButton(element).attr('disabled')).toBe('disabled');
@@ -146,8 +147,8 @@ describe('ouiTile', () => {
       const description = 'my description';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-definition term="${term}" description="${description}"></oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-definition term="${term}" description="${description}"></oui-tile-definition>
+        </oui-tile>`,
       );
 
       $timeout.flush();
@@ -161,16 +162,17 @@ describe('ouiTile', () => {
       const description = 'my description';
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-definition term="${term}" description="${description}"></oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-definition term="${term}" description="${description}"></oui-tile-definition>
+        </oui-tile>`,
       );
 
       const element2 = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-definition term="${term}">
-                        <oui-tile-description>${description}</oui-tile-description>
-                    </oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-definition>
+                <oui-tile-term>${term}</oui-tile-term>
+                <oui-tile-description>${description}</oui-tile-description>
+            </oui-tile-button>
+        </oui-tile>`,
       );
 
       expect(getTileDefinitionTerm(element).html()).toContain(term);
@@ -180,12 +182,25 @@ describe('ouiTile', () => {
       expect(getTileDefinitionDesc(element2).html()).toContain(description);
     });
 
+    it('should display actions', () => {
+      const actions = 'my actions';
+      const element = TestUtils.compileTemplate(
+        `<oui-tile>
+            <oui-tile-definition>
+                <oui-tile-actions>${actions}</oui-tile-actions>
+            </oui-tile-definition>
+        </oui-tile>`,
+      );
+
+      expect(getTileDefinitionActions(element).html()).toContain(actions);
+    });
+
     it('should define a term-popover', () => {
       const termPopover = 'my popover';
 
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-          <oui-tile-definition term-popover="${termPopover}"></oui-tile-button>
+            <oui-tile-definition term-popover="${termPopover}"></oui-tile-button>
         </oui-tile>`,
       );
 
@@ -201,18 +216,18 @@ describe('ouiTile', () => {
     it('should define an action-menu', () => {
       const element = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-definition>
-                        <oui-action-menu>
-                            <oui-action-menu-item></oui-action-menu-item>
-                        </oui-action-menu>
-                    </oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-definition>
+                <oui-action-menu>
+                    <oui-action-menu-item></oui-action-menu-item>
+                </oui-action-menu>
+            </oui-tile-button>
+        </oui-tile>`,
       );
 
       const element2 = TestUtils.compileTemplate(
         `<oui-tile>
-                    <oui-tile-definition></oui-tile-button>
-                </oui-tile>`,
+            <oui-tile-definition></oui-tile-definition>
+        </oui-tile>`,
       );
 
       expect(getActionMenu(element).length).not.toBe(0);


### PR DESCRIPTION
- add transclude `<oui-tile-term>`
- add transclude `<oui-tile-actions>`
- update stories
- update documentation
- update unit tests

Allow to add custom tags, to facilitate the migration.
For example:

```html
<div class="oui-tile__item">
    <dl class="oui-tile__definition">
        <dt class="oui-tile__term">
            <service-expiration-label></service-expiration-label>
        </dt>
        <dd class="oui-tile__description">
            <service-expiration-date></service-expiration-date>
        </dd>
    </dl>
    <div class="oui-tile__actions">
        <service-expiration-date></service-expiration-date>
    </div>
</div>
```