### PR TITLE
fix(oui-numeric): allow custom min and max values

### DIFF
--- a/packages/components/numeric/src/js/numeric.controller.js
+++ b/packages/components/numeric/src/js/numeric.controller.js
@@ -1,5 +1,4 @@
 import { addBooleanParameter, addDefaultParameter } from '@ovh-ux/ui-kit.core/src/js/component-utils';
-import clamp from 'lodash/clamp';
 
 // By design, value is restricted to [0, 99999] interval
 const MIN_VALUE = 0;
@@ -18,6 +17,8 @@ export default class {
 
   $onInit() {
     addDefaultParameter(this, 'id', `ouiNumeric${this.$id}`);
+    addDefaultParameter(this, 'min', MIN_VALUE);
+    addDefaultParameter(this, 'max', MAX_VALUE);
     addBooleanParameter(this, 'disabled');
 
     if (!angular.isNumber(this.min)) {
@@ -43,20 +44,9 @@ export default class {
       this.setModelValue(this.min);
     }
 
-    if (this.min < MIN_VALUE) {
-      this.$log.warn(`Invalid attribute min, value should be greater than '${MIN_VALUE}'`);
-    }
-
-    if (this.max > MAX_VALUE) {
-      this.$log.warn(`Invalid attribute max, value should be lower than '${MAX_VALUE}'`);
-    }
-
     if (angular.isDefined(this.$attrs.disabled) && angular.isUndefined(this.disabled)) {
       this.disabled = true;
     }
-
-    this.min = clamp(this.min, MIN_VALUE, MAX_VALUE);
-    this.max = clamp(this.max, this.min, MAX_VALUE);
 
     // used to trigger only onChange when necessary and
     // reset input if invalid characters are used

--- a/packages/components/numeric/src/js/numeric.spec.js
+++ b/packages/components/numeric/src/js/numeric.spec.js
@@ -67,6 +67,29 @@ describe('ouiNumeric', () => {
       expect(scope.foo).toBe(undefined);
     });
 
+    it('should allow custom min and max values', () => {
+      const elt = angular.element('<oui-numeric model="foo" min="-10" max="100000"></oui-numeric>');
+      const scope = $rootScope.$new();
+      const value1 = -11;
+      const value2 = -5;
+      const value3 = 100000;
+      const value4 = 100001;
+      $compile(elt)(scope);
+      scope.$digest();
+      elt.find('input').controller('ngModel').$setViewValue('-1');
+      expect(scope.foo).toBe(-1);
+      elt.find('input').controller('ngModel').$setViewValue('hello');
+      expect(scope.foo).toBe(undefined);
+      elt.find('input').controller('ngModel').$setViewValue(value1);
+      expect(scope.foo).toBe(undefined);
+      elt.find('input').controller('ngModel').$setViewValue(value2);
+      expect(scope.foo).toBe(value2);
+      elt.find('input').controller('ngModel').$setViewValue(value3);
+      expect(scope.foo).toBe(value3);
+      elt.find('input').controller('ngModel').$setViewValue(value4);
+      expect(scope.foo).toBe(undefined);
+    });
+
     it('should decrement value when clicking first button', () => {
       const elt = angular.element('<oui-numeric model="foo"></oui-numeric>');
       const scope = $rootScope.$new();


### PR DESCRIPTION
## fix(oui-numeric): allow custom min and max values

### Description of the Change



01196f09 — fix(oui-numeric): allow custom min and max values

### Related 

* https://github.com/ovh-ux/ovh-ui-angular/pull/430