### PR TITLE
feat(header-tabs): update tabs scrolling to allow scroll tab by tab

### DIFF
--- a/packages/apps/workshop/stories/components/header.stories.js
+++ b/packages/apps/workshop/stories/components/header.stories.js
@@ -1,5 +1,4 @@
 import { storiesOf } from '@storybook/html';
-import { text } from '@storybook/addon-knobs';
 import { forModule } from 'storybook-addon-angularjs';
 
 import { compileTemplate } from '../../src/utils';
@@ -38,9 +37,5 @@ storiesOf('Components/Header', module)
         <oui-header-tabs-item href="#">Datagrid</oui-header-tabs-item>
       </oui-header-tabs>
     </oui-header>
-    `, {
-      $ctrl: {
-        model: text('Model', 'Copy this text'),
-      },
-    })),
+    `)),
   );

--- a/packages/components/header/src/js/tabs/header-tabs.controller.js
+++ b/packages/components/header/src/js/tabs/header-tabs.controller.js
@@ -1,28 +1,63 @@
-import findIndex from 'lodash/findIndex';
-
-const checkScrollDelay = 800;
+import filter from 'lodash/filter';
 
 export default class {
-  constructor($attrs, $element, $interval, $scope, $timeout, $window) {
+  constructor($element, $scope, $timeout, $window) {
     'ngInject';
 
-    this.$attrs = $attrs;
     this.$element = $element;
-    this.$interval = $interval;
     this.$scope = $scope;
     this.$timeout = $timeout;
     this.$window = $window;
   }
 
+  checkScroll() {
+    this.$timeout(() => {
+      this.canScroll = this.tabsList.clientWidth < this.tabsList.scrollWidth;
+
+      // Reset scroll value
+      this.canScrollLeft = false;
+      this.canScrollRight = true;
+      this.scrollIndex = 0;
+      this.tabsList.style.transform = 'translateX(0)';
+    });
+  }
+
+  getOffsetLeft() {
+    // Here we set temporary the position to 'relative',
+    // to get the right offsetLeft with for reference the list container.
+    // Because we could have dropdown, we can't set the position to 'relative' in the CSS,
+    // or else the overflow will hidden the dropdown menu
+    this.tabsList.style.position = 'relative';
+    const { offsetLeft } = this.tabs[this.scrollIndex];
+    this.tabsList.style.position = 'static';
+
+    return offsetLeft;
+  }
+
+  scrollTo(direction) {
+    const minIndex = 0;
+    const maxIndex = this.tabs.length - 1;
+
+    if (direction === 'left') {
+      this.scrollIndex = Math.max(this.scrollIndex - 1, minIndex);
+    } else {
+      this.scrollIndex = Math.min(this.scrollIndex + 1, maxIndex);
+    }
+
+    this.canScrollLeft = this.scrollIndex > minIndex;
+    this.canScrollRight = this.scrollIndex < maxIndex;
+
+    // The slide animation is done in the CSS
+    // with a transition targeting the transform property
+    this.tabsList.style.transform = `translateX(-${this.getOffsetLeft()}px)`;
+  }
+
   $onInit() {
-    this.scroll = {
-      begin: 0,
-      end: 0,
-    };
+    this.tabs = [];
   }
 
   $onDestroy() {
-    angular.element(this.tabsElement).off('scroll');
+    angular.element(this.tabsList).off('scroll');
     angular.element(this.$window).off('resize');
   }
 
@@ -31,107 +66,14 @@ export default class {
       this.$element
         .addClass('oui-header-tabs');
 
-      this.tabsElement = this.$element[0].querySelector('.oui-header-tabs__container');
-      angular.element(this.tabsElement).on('scroll', event => this.checkScroll(event));
-      angular.element(this.$window).on('resize', event => this.checkScroll(event));
-      this.initialCheck();
+      this.tabsList = this.$element[0].querySelector('.oui-header-tabs__list');
+      this.$scope.$watch(() => this.tabsList.childNodes.length, () => {
+        this.tabs = filter(this.tabsList.childNodes, node => node.nodeType === 1);
+        this.checkScroll();
+      });
     });
 
-    /* On initial render, we need to wait few seconds before calling
-           the checkScroll method otherwise panel size would be wrong. */
-    this.$timeout(() => this.initialCheck(), checkScrollDelay);
-  }
-
-  scrollLeft() {
-    this.scrollTo('left');
-  }
-
-  scrollRight() {
-    this.scrollTo('right');
-  }
-
-  initialCheck() {
-    const activeTab = this.$element[0].querySelector('.oui-header-tabs__item_active');
-    if (activeTab && activeTab.offsetLeft - this.tabsElement.offsetLeft > 0) {
-      this.tabsElement.scrollLeft = activeTab.offsetLeft - this.tabsElement.offsetLeft;
-    } else {
-      this.scroll.end = this.tabsElement.scrollWidth - this.tabsElement.offsetWidth;
-    }
-  }
-
-  scrollTo(direction) {
-    const itemToGo = this.findItemToGo(direction);
-    this.scrollToItem(direction, itemToGo);
-  }
-
-  checkScroll(e) {
-    if (e) {
-      e.preventDefault();
-    }
-
-    this.scroll.begin = this.tabsElement.scrollLeft;
-    this.scroll.end = this.tabsElement.scrollWidth
-      - this.tabsElement.offsetWidth
-      - this.tabsElement.scrollLeft;
-    this.$scope.$digest();
-  }
-
-  findItemToGo(direction) {
-    if (!this.tabsElement || !direction) {
-      return undefined;
-    }
-
-    const tabsList = [].slice.call(this.tabsElement.querySelectorAll(':scope > oui-header-tabs-item'));
-    const tabsOffset = this.tabsElement.offsetLeft;
-    const tabsStart = this.tabsElement.scrollLeft;
-    const tabsEnd = tabsStart + this.tabsElement.offsetWidth;
-
-    let itemGutter = 0;
-    if (tabsList && tabsList.length > 1) {
-      itemGutter = tabsList[1].offsetLeft - (tabsList[0].offsetLeft + tabsList[0].offsetWidth);
-    }
-
-    const index = findIndex(tabsList, (item) => {
-      const itemStart = item.offsetLeft - tabsOffset;
-      return !(direction === 'right' && itemStart <= tabsEnd + tabsOffset + itemGutter)
-        && !(direction === 'left' && itemStart < tabsStart);
-    });
-
-    return tabsList[Math.max(index - 1, 0)];
-  }
-
-  scrollToItem(direction, item) {
-    if (!this.tabsElement || !item || !direction) {
-      return;
-    }
-
-    const duration = 500;
-    const stepDuration = 15;
-    const step = this.tabsElement.scrollWidth / (duration / stepDuration);
-
-    const itemStart = item.offsetLeft - this.tabsElement.offsetLeft;
-    const itemEnd = itemStart + item.offsetWidth;
-    const tabsWidth = this.tabsElement.offsetWidth;
-
-    const loop = this.$interval(() => {
-      const tabsStart = this.tabsElement.scrollLeft;
-      const tabsEnd = this.tabsElement.scrollWidth
-        - this.tabsElement.offsetWidth
-        - this.tabsElement.scrollLeft;
-      const screenEnd = tabsStart + this.tabsElement.offsetWidth;
-
-      if (direction === 'right' && tabsEnd > 0 && (tabsStart + step < itemStart || itemEnd > screenEnd)) {
-        this.tabsElement.scrollLeft += step;
-      } else if (direction === 'left' && tabsStart > 0 && (screenEnd - step > itemEnd || itemStart < tabsStart - step)) {
-        this.tabsElement.scrollLeft -= step;
-      } else {
-        if (direction === 'right') {
-          this.tabsElement.scrollLeft = tabsStart <= itemStart ? itemStart : itemEnd - tabsWidth;
-        } else {
-          this.tabsElement.scrollLeft = tabsStart >= itemStart ? itemStart : itemEnd - tabsWidth;
-        }
-        this.$interval.cancel(loop);
-      }
-    }, stepDuration);
+    angular.element(this.tabsList).on('scroll', () => this.checkScroll());
+    angular.element(this.$window).on('resize', () => this.checkScroll());
   }
 }

--- a/packages/components/header/src/js/tabs/header-tabs.html
+++ b/packages/components/header/src/js/tabs/header-tabs.html
@@ -1,13 +1,17 @@
 <nav class="oui-header-tabs__nav">
-    <button type="button" class="oui-header-tabs__slider oui-header-tabs__slider_left oui-icon oui-icon-chevron-left" aria-hidden="true"
-            ng-click="$ctrl.scrollLeft()"
-            ng-show="$ctrl.scroll.begin > 0">
+    <button type="button"
+        class="oui-header-tabs__slider oui-header-tabs__slider_left oui-icon oui-icon-chevron-left" aria-hidden="true"
+        ng-click="$ctrl.scrollTo('left')"
+        ng-show="$ctrl.canScroll && $ctrl.canScrollLeft">
     </button>
-    <div class="oui-header-tabs__container" role="list"
-        ng-transclude>
+    <div class="oui-header-tabs__container">
+        <div class="oui-header-tabs__list" role="list"
+            ng-transclude>
+        </div>
     </div>
-    <button type="button" class="oui-header-tabs__slider oui-header-tabs__slider_right oui-icon oui-icon-chevron-right" aria-hidden="true"
-            ng-click="$ctrl.scrollRight()"
-            ng-show="$ctrl.scroll.end > 0">
+    <button type="button"
+        class="oui-header-tabs__slider oui-header-tabs__slider_right oui-icon oui-icon-chevron-right" aria-hidden="true"
+        ng-click="$ctrl.scrollTo('right')"
+        ng-show="$ctrl.canScroll && $ctrl.canScrollRight">
     </button>
 </nav>

--- a/packages/components/header/src/js/tabs/header-tabs.spec.js
+++ b/packages/components/header/src/js/tabs/header-tabs.spec.js
@@ -19,7 +19,7 @@ describe('ouiHeaderTabs', () => {
 
       $timeout.flush();
 
-      const container = element[0].querySelector('.oui-header-tabs__container');
+      const container = element[0].querySelector('.oui-header-tabs__list');
       const $container = angular.element(container);
       expect($container.children().length).toBe(1);
       expect($container.attr('role')).toBe('list');
@@ -90,7 +90,7 @@ describe('ouiHeaderTabs', () => {
 
       $timeout.flush();
 
-      const container = element[0].querySelector('.oui-header-tabs__container');
+      const container = element[0].querySelector('.oui-header-tabs__list');
       expect(angular.element(container).children().length).toBe(1);
       const trigger = container.querySelector('.oui-dropdown__trigger');
       const $trigger = angular.element(trigger);

--- a/packages/components/header/src/less/header-tabs.less
+++ b/packages/components/header/src/less/header-tabs.less
@@ -106,13 +106,24 @@
   }
 
   &__container {
-    display: flex;
-    flex-wrap: nowrap;
     list-style: none;
     margin: @oui-header-tabs-margin;
     overflow: hidden;
     padding: 0;
     border-bottom: @oui-header-tabs-border-bottom;
+
+    ul& {
+      display: flex;
+      flex-wrap: nowrap;
+    }
+  }
+
+  &__list {
+    display: flex;
+    flex-wrap: nowrap;
+    transform: translateX(0);
+    transition: transform 0.25s ease;
+    will-change: transform;
   }
 
   &__slider {


### PR DESCRIPTION
- Remove $interval animation to prefer CSS animation
- Simplify the code for the scrolling to avoid value calculation, and rely on tabs `offsetLeft` value