### PR TITLE
fix(oui-dropdown): afterClose should remove the focus

### DIFF
--- a/packages/components/dropdown/src/js/trigger/dropdown-trigger.controller.js
+++ b/packages/components/dropdown/src/js/trigger/dropdown-trigger.controller.js
@@ -61,6 +61,7 @@ export default class {
 
   afterClose() {
     this.$trigger.attr('aria-expanded', false);
+    this.$trigger[0].blur();
     this.$trigger.off('keydown');
   }
 }


### PR DESCRIPTION
## `afterClose` should remove the focus

### Description of the Change

#### :bug: Bug Fix

fix(oui-dropdown): afterClose should remove the focus

#### :link: Related

- https://github.com/ovh-ux/ovh-ui-angular/pull/449

### Benefits

Focus of the element is correctly removed by using [`.blur()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/blur).

### Possible Drawbacks

None.

### Applicable Issues

None.

## :house: Internal

- No quality check required.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>
