### PR TITLE
fix(navbar): remove max-height on notification description

### DIFF
--- a/packages/base/core/src/less/_variables.less
+++ b/packages/base/core/src/less/_variables.less
@@ -1295,7 +1295,7 @@
 @oui-navbar-notification-title-font-weight: @oui-font-semibold;
 
 @oui-navbar-notification-description-line-height: rem-calc(20);
-@oui-navbar-notification-description-max-height: calc(@oui-navbar-notification-description-line-height * 4);
+@oui-navbar-notification-description-max-height: none;
 @oui-navbar-notification-description-font-size: rem-calc(14);
 @oui-navbar-notification-description-font-weight: @oui-font-regular;
 


### PR DESCRIPTION
Remove max-height on notification description, that comes from previous guidelines