### PR TITLE
fix(button): fix invalid calculated value

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "indentation": [2, { "ignore": ["inside-parens"] }],
     "function-calc-no-invalid": null,
+    "length-zero-no-unit": null,
     "no-descending-specificity": null,
     "selector-type-no-unknown": [true, { "ignore": ["custom-elements"] }]
   }

--- a/packages/base/core/src/less/variables/components/button.less
+++ b/packages/base/core/src/less/variables/components/button.less
@@ -12,7 +12,7 @@
 @oui-button-font-size: rem-calc(16);
 @oui-button-font-weight: @oui-font-semibold;
 @oui-button-radius: @base-border-radius-medium;
-@oui-button-border-width: 0;
+@oui-button-border-width: 0px; // Need unit for calculation
 @oui-button-background-color: transparent;
 
 // Button - Icons
@@ -30,7 +30,7 @@
 @oui-button-primary-padding: calc(@oui-button-padding-y - @oui-button-primary-border-width) calc(@oui-button-padding-x - @oui-button-primary-border-width);
 @oui-button-primary-padding_small: calc(@oui-button-small-padding-y - @oui-button-primary-border-width) calc(@oui-button-small-padding-x - @oui-button-primary-border-width);
 @oui-button-primary-padding_large: calc(@oui-button-large-padding-y - @oui-button-primary-border-width) calc(@oui-button-large-padding-x - @oui-button-primary-border-width);
-@oui-button-primary-border-width: 0;
+@oui-button-primary-border-width: 0px; // Need unit for calculation
 @oui-button-primary-background-color: @p-500;
 @oui-button-primary-background-color_hover: @p-700;
 @oui-button-primary-background-color_active: @p-800;


### PR DESCRIPTION
Having value `0` without unit in a `calc()` cause error `invalid value`.
To resolve the problem, I've added `px` to the value.

This has no side effect, except resolving this issue.