### PR TITLE
fix(select): fix states colors

### DIFF
--- a/packages/components/select/src/less/select.less
+++ b/packages/components/select/src/less/select.less
@@ -78,6 +78,9 @@
         );
       }
     }
+
+    // States
+    #oui > .select-states();
   }
 
   // Inline variant
@@ -86,9 +89,6 @@
     vertical-align: top;
     width: auto;
   }
-
-  // States
-  #oui > .select-states();
 
   // Sizes
   #oui > .control-sizes();


### PR DESCRIPTION
The mixin was misplaced. The states colors was applied on the wrong element.